### PR TITLE
Remove OpenAI ChatGPT, Use Ollama llama-3 or phi-3

### DIFF
--- a/src/app_streamlit.py
+++ b/src/app_streamlit.py
@@ -22,7 +22,7 @@ COMPANY_NAME = "ExplAIstic"
 
 COMPANY_LOGO = os.path.join(Path.cwd(), "resources", "Background.png")
 BACKGROUND_IMAGE = os.path.join(Path.cwd(), "resources", "Background.png")
-CHATBOT = generate_caption.Chatbot(os.environ["OPENAI_API_KEY"])
+CHATBOT = generate_caption.Chatbot()
 IMAGE_CAPTION_GENERATOR = generate_caption.ImageCaptionGenerator(CHATBOT)
 GIPHY_IMAGE = os.path.join(Path.cwd(), "resources", "giphy.gif")
 
@@ -163,10 +163,7 @@ def stream_text(stream):
     full_text = ''
 
     for chunk in stream:
-        new_text = chunk.choices[0].delta.content \
-        if (chunk.choices[0].delta and chunk.choices[0].delta.content)\
-        else ''
-        full_text += new_text
+        full_text += chunk['message']['content']
         success_stream.success(full_text)
         time.sleep(0.05)
 

--- a/src/generate_caption/generate_caption.py
+++ b/src/generate_caption/generate_caption.py
@@ -56,7 +56,7 @@ class Chatbot:
             options={
                 'temperature': 0,
                 'top_p': 0.9 
-            },           
+            },
         )
         return response
 


### PR DESCRIPTION
- Get rid of OpenAI's ChatGPT
- No more expensive API calling
- Use Ollama to locally run the language models
- Use llama-3 (8 Billion Parameters, small one)
- Use Phi-3 (3 Billion Parameters, SLM)